### PR TITLE
Add vote event for result set

### DIFF
--- a/contracts/oracles/CentralizedOracle.sol
+++ b/contracts/oracles/CentralizedOracle.sol
@@ -78,7 +78,7 @@ contract CentralizedOracle is Oracle {
         balances[_resultIndex].bets[msg.sender] = balances[_resultIndex].bets[msg.sender].add(msg.value);
 
         ITopicEvent(eventAddress).betFromOracle.value(msg.value)(msg.sender, _resultIndex);
-        OracleResultVoted(version, address(this), msg.sender, _resultIndex, msg.value);
+        OracleResultVoted(version, address(this), msg.sender, _resultIndex, msg.value, QTUM);
     }
 
     /* 

--- a/contracts/oracles/CentralizedOracle.sol
+++ b/contracts/oracles/CentralizedOracle.sol
@@ -104,6 +104,7 @@ contract CentralizedOracle is Oracle {
             .add(consensusThreshold);
 
         ITopicEvent(eventAddress).centralizedOracleSetResult(msg.sender, _resultIndex, consensusThreshold);
+        OracleResultVoted(version, address(this), msg.sender, _resultIndex, consensusThreshold, BOT);
         OracleResultSet(version, address(this), _resultIndex);
     }
 }

--- a/contracts/oracles/DecentralizedOracle.sol
+++ b/contracts/oracles/DecentralizedOracle.sol
@@ -65,7 +65,7 @@ contract DecentralizedOracle is Oracle {
             .add(adjustedVoteAmount);
 
         ITopicEvent(eventAddress).voteFromOracle(_eventResultIndex, msg.sender, adjustedVoteAmount);
-        OracleResultVoted(version, address(this), msg.sender, _eventResultIndex, adjustedVoteAmount);
+        OracleResultVoted(version, address(this), msg.sender, _eventResultIndex, adjustedVoteAmount, BOT);
 
         if (balances[_eventResultIndex].totalVotes >= consensusThreshold) {
             setResult();

--- a/contracts/oracles/Oracle.sol
+++ b/contracts/oracles/Oracle.sol
@@ -21,7 +21,7 @@ contract Oracle is BaseContract, Ownable {
         address indexed _oracleAddress, 
         address indexed _participant, 
         uint8 _resultIndex, 
-        uint256 _votedAmount
+        uint256 _votedAmount,
         bytes32 _token);
     event OracleResultSet(
         uint16 indexed _version, 

--- a/contracts/oracles/Oracle.sol
+++ b/contracts/oracles/Oracle.sol
@@ -8,6 +8,9 @@ import "../libs/SafeMath.sol";
 contract Oracle is BaseContract, Ownable {
     using SafeMath for uint256;
 
+    bytes32 internal constant QTUM = "QTUM";
+    bytes32 internal constant BOT = "BOT";
+
     bool public finished;
     address public eventAddress;
     uint256 public consensusThreshold;
@@ -18,7 +21,8 @@ contract Oracle is BaseContract, Ownable {
         address indexed _oracleAddress, 
         address indexed _participant, 
         uint8 _resultIndex, 
-        uint256 _votedAmount);
+        uint256 _votedAmount
+        bytes32 _token);
     event OracleResultSet(
         uint16 indexed _version, 
         address indexed _oracleAddress, 


### PR DESCRIPTION
1. Emit an `OracleResultVoted` when COracle result set is emitted too.
2. Add `token` type field for `OracleResultVoted` event

This is needed because on UI side, we are querying the vote table to determine winning addresses. I thought about just adding another query on UI to result set table, but that is just a workaround to the core issue.

We should be treating COracle result set as a vote as well. It's part of the vote total and calculated as part of the winnings. So we should be adding a vote entry for this as well and made sense to me for it to be adding it from the contract side.